### PR TITLE
Update krux's amp-analytics vender configuration for user consent request url

### DIFF
--- a/extensions/amp-analytics/0.1/vendors/krux.json
+++ b/extensions/amp-analytics/0.1/vendors/krux.json
@@ -4,7 +4,7 @@
     "timing": "t_navigation_type=0&t_dns=${domainLookupTime}&t_tcp=${tcpConnectTime}&t_http_request=${serverResponseTime}&t_http_response=${pageDownloadTime}&t_content_ready=${contentLoadTime}&t_window_load=${pageLoadTime}&t_redirect=${redirectTime}",
     "common": "source=amp&confid=${confid}&_kpid=${pubid}&_kcp_s=${site}&_kcp_sc=${section}&_kcp_ssc=${subsection}&_kcp_d=${canonicalHost}&_kpref_=${documentReferrer}&_kua_kx_amp_client_id=${clientId(_kuid_)}&_kua_kx_lang=${browserLanguage}&_kua_kx_tech_browser_language=${browserLanguage}&_kua_kx_tz=${timezone}",
     "pageview": "${beaconHost}/pixel.gif?${common}&${timing}",
-    "event": "${beaconHost}/event.gif?${common}&${timing}&pageview=false"
+    "event": "${beaconHost}/event.gif?${common}&${timing}&pageview=false",
     "setConsent": "https://consumer.krxd.net/consent/set/${longOrgId}?idt=${idt}&dt=${dt}&dc=${dc}&al=${al}&tg=${tg}&cd=${cd}&sh=${sh}&re=${re}&idv=${clientId(_kuid_)}"
   },
   "transport": {

--- a/extensions/amp-analytics/0.1/vendors/krux.json
+++ b/extensions/amp-analytics/0.1/vendors/krux.json
@@ -5,6 +5,7 @@
     "common": "source=amp&confid=${confid}&_kpid=${pubid}&_kcp_s=${site}&_kcp_sc=${section}&_kcp_ssc=${subsection}&_kcp_d=${canonicalHost}&_kpref_=${documentReferrer}&_kua_kx_amp_client_id=${clientId(_kuid_)}&_kua_kx_lang=${browserLanguage}&_kua_kx_tech_browser_language=${browserLanguage}&_kua_kx_tz=${timezone}",
     "pageview": "${beaconHost}/pixel.gif?${common}&${timing}",
     "event": "${beaconHost}/event.gif?${common}&${timing}&pageview=false"
+    "setConsent": "https://consumer.krxd.net/consent/set/${longOrgId}?idt=${idt}&dt=${dt}&dc=${dc}&al=${al}&tg=${tg}&cd=${cd}&sh=${sh}&re=${re}&idv=${clientId(_kuid_)}"
   },
   "transport": {
     "beacon": false,


### PR DESCRIPTION
Fixes for the User Consent implementation for AMP Analytics

Krux official documentation available at https://konsole.zendesk.com/hc/en-us/articles/216596608-AMP-Integration-Guide . But it's not working as expected because of missing declaration for the `setConsent` request url in the amp-analytics krux vender configuration file.

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
